### PR TITLE
Delete config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Major enhancement
-    url: https://github.com/hashgraph/hedera-improvement-proposal
-    about: Propose a major feature using our Hedera Improvement Proposal (HIP) process


### PR DESCRIPTION
**Description**:
For private repos, only the config.yml was taking effect. They ignored the other issue templates. This caused private repos to only support creating a HIP.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
